### PR TITLE
Add AssumableByComputeService findings to role detail output

### DIFF
--- a/cloudsplaining/scan/assume_role_policy_document.py
+++ b/cloudsplaining/scan/assume_role_policy_document.py
@@ -82,6 +82,10 @@ class AssumeRoleStatement(ResourceStatement):
         if "sts:AssumeRole".lower() not in lowercase_actions:
             return []
 
+        # Effect must be Allow
+        if self.effect.lower() != "allow":
+            return []
+
         assumable_by_compute_services = []
         for principal in self.principals:
             if principal.endswith(".amazonaws.com"):

--- a/cloudsplaining/scan/role_details.py
+++ b/cloudsplaining/scan/role_details.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from cloudsplaining.scan.assume_role_policy_document import AssumeRolePolicyDocument
 from cloudsplaining.scan.inline_policy import InlinePolicy
 from cloudsplaining.shared import utils
+from cloudsplaining.shared.constants import ISSUE_SEVERITY, RISK_DEFINITION
 from cloudsplaining.shared.exceptions import NotFoundException
 from cloudsplaining.shared.exclusions import (
     DEFAULT_EXCLUSIONS,
@@ -147,6 +148,7 @@ class RoleDetail:
         :param policy_details: The ManagedPolicyDetails object - i.e., details about all managed policies in the account
         so the role can inherit those attributes
         """
+        self.severity = [] if severity is None else severity
         # Metadata
         self.path = role_detail["Path"]
         self.role_name = role_detail["RoleName"]
@@ -330,5 +332,18 @@ class RoleDetail:
             customer_managed_policies=self.attached_customer_managed_policies_pointer_json,
             aws_managed_policies=self.attached_aws_managed_policies_pointer_json,
             is_excluded=self.is_excluded,
+            AssumableByComputeServices={
+                "severity": ISSUE_SEVERITY["AssumableByComputeService"],
+                "description": RISK_DEFINITION["AssumableByComputeService"],
+                "findings": (
+                    self.assume_role_policy_document.role_assumable_by_compute_services
+                    if self.assume_role_policy_document
+                    and (
+                        ISSUE_SEVERITY["AssumableByComputeService"] in [x.lower() for x in self.severity]
+                        or not self.severity
+                    )
+                    else []
+                ),
+            },
         )
         return this_role_detail

--- a/test/files/scanning/test_role_detail_results.json
+++ b/test/files/scanning/test_role_detail_results.json
@@ -16,7 +16,7 @@
   },
   "aws_managed_policies": {},
   "create_date": "2018-08-20 18:48:00+00:00",
-  "customer_managed_policies": {"InsecurePolicy": "InsecurePolicy"},
+  "customer_managed_policies": { "InsecurePolicy": "InsecurePolicy" },
   "id": "OverprivilegedEC2",
   "inline_policies": {
     "d09fe3603cd65058b6e2d9817cf37093e83e98318a56ce1e29c8491ac989e57e": "SupYo"
@@ -55,5 +55,10 @@
   "is_excluded": false,
   "name": "OverprivilegedEC2",
   "path": "/",
-  "role_last_used": "2019-01-20 18:48:00+00:00"
+  "role_last_used": "2019-01-20 18:48:00+00:00",
+  "AssumableByComputeServices": {
+    "description": "<p>IAM Roles can be assumed by AWS Compute Services (such as EC2, ECS, EKS, or Lambda) can present greater risk than user-defined roles, especially if the AWS Compute service is on an instance that is directly or indirectly exposed to the internet. Flagging these roles is particularly useful to penetration testers (or attackers) under certain scenarios.<br>For example, if an attacker obtains privileges to execute <code>ssm:SendCommand</code> and there are privileged EC2 instances with the SSM agent installed, they can effectively have the privileges of those EC2 instances.</p>",
+    "findings": ["ec2"],
+    "severity": "low"
+  }
 }

--- a/test/scanning/test_trust_policies.py
+++ b/test/scanning/test_trust_policies.py
@@ -1,5 +1,6 @@
-from cloudsplaining.scan.assume_role_policy_document import AssumeRoleStatement
 import unittest
+
+from cloudsplaining.scan.assume_role_policy_document import AssumeRoleStatement
 
 
 class TestAssumeRole(unittest.TestCase):
@@ -131,3 +132,12 @@ class TestAssumeRole(unittest.TestCase):
         )
         assume_role_empty_actions_statement = AssumeRoleStatement(empty_actions_statement)
         self.assertListEqual(assume_role_empty_actions_statement.actions, [])
+
+        # Case: Deny statement, for a  compute service
+        deny_statement = dict(
+            Effect="Deny",
+            Principal={"Service": ["lambda.amazonaws.com"]},
+            Action=["sts:AssumeRole"],
+        )
+        assume_role_deny_statement = AssumeRoleStatement(deny_statement)
+        self.assertListEqual(assume_role_deny_statement.role_assumable_by_compute_services, [])


### PR DESCRIPTION
This pull request introduces improvements to how IAM roles assumable by AWS compute services are identified and reported, with a focus on risk assessment and output clarity. The main changes ensure that only "Allow" statements are considered for compute service assumption, enrich the risk output for these roles, and update related tests and data structures.

**Assume Role Policy Evaluation:**

* Updated `role_assumable_by_compute_services` logic in `assume_role_policy_document.py` to only return compute services if the statement effect is `"Allow"`, filtering out `"Deny"` statements for accuracy.

**Risk Reporting and Output Structure:**

* Enhanced the output in `role_details.py` to include an `AssumableByComputeServices` section with severity, description, and findings, using shared constants for consistency. [[1]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR12) [[2]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR335-R347)
* Added a `severity` attribute to the role details class to track risk levels for findings.

**Test and Data Updates:**

* Updated test data in `test_role_detail_results.json` to reflect the new `AssumableByComputeServices` output structure, including severity, description, and findings.
* Added a new test case in `test_trust_policies.py` to verify that `"Deny"` statements do not result in compute service findings, ensuring correct logic in edge cases.

**Code Maintenance:**

* Minor import reordering for clarity and consistency in `test_trust_policies.py`.Surface compute service assumability findings at the role level to provide better visibility into roles that can be assumed by EC2, ECS, EKS, or Lambda services, helping security teams identify potential privilege escalation paths through compute services.
