### PR TITLE
Add AssumableByCrossAccountPrincipal findings to role detail output

### DIFF
--- a/cloudsplaining/shared/constants.py
+++ b/cloudsplaining/shared/constants.py
@@ -83,6 +83,7 @@ ISSUE_SEVERITY = {
     "CredentialsExposure": "high",
     "InfrastructureModification": "low",
     "AssumableByComputeService": "low",
+    "AssumableByCrossAccountPrincipal": "low",
 }
 
 RISK_DEFINITION = {
@@ -93,6 +94,7 @@ RISK_DEFINITION = {
     "CredentialsExposure": "<p>Credentials Exposure actions return credentials as part of the API response , such as ecr:GetAuthorizationToken, iam:UpdateAccessKey, and others. The full list is maintained here: https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a</p>",
     "InfrastructureModification": "",
     "AssumableByComputeService": "<p>IAM Roles can be assumed by AWS Compute Services (such as EC2, ECS, EKS, or Lambda) can present greater risk than user-defined roles, especially if the AWS Compute service is on an instance that is directly or indirectly exposed to the internet. Flagging these roles is particularly useful to penetration testers (or attackers) under certain scenarios.<br>For example, if an attacker obtains privileges to execute <code>ssm:SendCommand</code> and there are privileged EC2 instances with the SSM agent installed, they can effectively have the privileges of those EC2 instances.</p>",
+    "AssumableByCrossAccountPrincipal": "<p>Roles that can be assumed from other AWS accounts can present a greater risk than roles that can only be assumed within the same AWS account. This is especially true if the trusting account is not owned by your organization.</p>",
 }
 
 PRIVILEGE_ESCALATION_METHODS = {

--- a/test/files/scanning/test_role_detail_results.json
+++ b/test/files/scanning/test_role_detail_results.json
@@ -60,5 +60,10 @@
     "description": "<p>IAM Roles can be assumed by AWS Compute Services (such as EC2, ECS, EKS, or Lambda) can present greater risk than user-defined roles, especially if the AWS Compute service is on an instance that is directly or indirectly exposed to the internet. Flagging these roles is particularly useful to penetration testers (or attackers) under certain scenarios.<br>For example, if an attacker obtains privileges to execute <code>ssm:SendCommand</code> and there are privileged EC2 instances with the SSM agent installed, they can effectively have the privileges of those EC2 instances.</p>",
     "findings": ["ec2"],
     "severity": "low"
+  },
+  "AssumableByCrossAccountPrincipal": {
+    "description": "<p>Roles that can be assumed from other AWS accounts can present a greater risk than roles that can only be assumed within the same AWS account. This is especially true if the trusting account is not owned by your organization.</p>",
+    "findings": [],
+    "severity": "low"
   }
 }


### PR DESCRIPTION
This pull request adds the ability to detect and report IAM roles that are assumable by principals from other AWS accounts (cross-account principals), alongside existing detection for compute service principals. It introduces new logic to extract and aggregate these cross-account principals, updates the role details JSON output to include findings and risk descriptions for both compute service and cross-account assumptions, and expands test coverage for these scenarios.

### Cross-account principal detection and reporting

* Added logic in `AssumeRoleStatement` and `AssumeRolePolicyDocument` to identify principals from other AWS accounts that can assume a role, filtering out the current account if known. This is exposed via the new `role_assumable_by_cross_account_principals` property. [[1]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5R53-R70) [[2]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5R99-R132)
* Updated `RoleDetails` to extract the current account ID from the role ARN and pass it to the trust policy parser, enabling accurate cross-account filtering.

### Role details output enhancements

* Extended the role JSON output to include new `AssumableByComputeServices` and `AssumableByCrossAccountPrincipal` sections, each with severity, description, and findings, using values from `ISSUE_SEVERITY` and `RISK_DEFINITION`. [[1]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR345-R370) [[2]](diffhunk://#diff-15b2db1f8d7430389bfa53b5cff55882537ed8c454e2fb24fa5367edea4c184cR86) [[3]](diffhunk://#diff-15b2db1f8d7430389bfa53b5cff55882537ed8c454e2fb24fa5367edea4c184cR97) [[4]](diffhunk://#diff-db7efb559c14a77b80cdeefe9d227804effb12b7e30680efe95322f8443c8aa7L58-R68)
* Ensured severity filtering is respected for these new findings in the output. [[1]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR154) [[2]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR345-R370)

### Test coverage

* Added and expanded unit tests for cross-account principal detection, including edge cases for effect, action, and principal type, and aggregation at the policy document level.

### Dependency and import updates

* Imported `get_account_from_arn` and `contextlib` where needed to support account ID extraction and error suppression during principal parsing. [[1]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5R10-R15) [[2]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR5-R15)

These changes improve the tool's ability to surface potential cross-account role assumption risks, making findings more actionable for security review.## What does this PR do?

