### PR TITLE
Add --flag-trust-policies CLI option to toggle trust policy findings

### DIFF
--- a/cloudsplaining/command/scan.py
+++ b/cloudsplaining/command/scan.py
@@ -96,6 +96,14 @@ from cloudsplaining.shared.validation import check_authorization_details_schema
     multiple=True,
     type=click.Choice(["CRITICAL", "HIGH", "MEDIUM", "LOW", "NONE"], case_sensitive=False),
 )
+@click.option(
+    "-t",
+    "--flag-trust-policies",
+    required=False,
+    default=False,
+    is_flag=True,
+    help="Flag risky trust policies in roles.",
+)
 def scan(
     input_file: str,
     exclusions_file: str,
@@ -105,6 +113,7 @@ def scan(
     flag_all_risky_actions: bool,
     verbosity: int,
     severity: list[str],
+    flag_trust_policies: bool,
 ) -> None:  # pragma: no cover
     """
     Given the path to account authorization details files and the exclusions config file, scan all inline and
@@ -142,6 +151,7 @@ def scan(
             minimize=minimize,
             flag_conditional_statements=flag_conditional_statements,
             flag_resource_arn_statements=flag_resource_arn_statements,
+            flag_trust_policies=flag_trust_policies,
             severity=severity,
         )
         html_output_file = os.path.join(output, f"iam-report-{account_name}.html")
@@ -207,6 +217,7 @@ def scan_account_authorization_details(
     return_json_results: Literal[True],
     flag_conditional_statements: bool = ...,
     flag_resource_arn_statements: bool = ...,
+    flag_trust_policies: bool = ...,
     severity: list[str] | None = ...,
 ) -> dict[str, Any]: ...
 
@@ -222,6 +233,7 @@ def scan_account_authorization_details(
     return_json_results: Literal[False] = ...,
     flag_conditional_statements: bool = ...,
     flag_resource_arn_statements: bool = ...,
+    flag_trust_policies: bool = ...,
     severity: list[str] | None = ...,
 ) -> str: ...
 
@@ -236,6 +248,7 @@ def scan_account_authorization_details(
     return_json_results: bool = False,
     flag_conditional_statements: bool = False,
     flag_resource_arn_statements: bool = False,
+    flag_trust_policies: bool = False,
     severity: list[str] | None = None,
 ) -> str | dict[str, Any]:  # pragma: no cover
     """
@@ -250,6 +263,7 @@ def scan_account_authorization_details(
         exclusions=exclusions,
         flag_conditional_statements=flag_conditional_statements,
         flag_resource_arn_statements=flag_resource_arn_statements,
+        flag_trust_policies=flag_trust_policies,
         severity=severity,
     )
     results = authorization_details.results

--- a/cloudsplaining/scan/authorization_details.py
+++ b/cloudsplaining/scan/authorization_details.py
@@ -35,6 +35,7 @@ class AuthorizationDetails:
         exclusions: Exclusions = DEFAULT_EXCLUSIONS,
         flag_conditional_statements: bool = False,
         flag_resource_arn_statements: bool = False,
+        flag_trust_policies: bool = False,
         severity: list[str] | None = None,
     ) -> None:
         """
@@ -53,6 +54,7 @@ class AuthorizationDetails:
         self.exclusions = exclusions
         self.flag_conditional_statements = flag_conditional_statements
         self.flag_resource_arn_statements = flag_resource_arn_statements
+        self.flag_trust_policies = flag_trust_policies
 
         self.policies = ManagedPolicyDetails(
             auth_json.get("Policies", []),
@@ -86,6 +88,7 @@ class AuthorizationDetails:
             exclusions,
             flag_conditional_statements=flag_conditional_statements,
             flag_resource_arn_statements=flag_resource_arn_statements,
+            flag_trust_policies=flag_trust_policies,
             severity=severity,
         )
 

--- a/test/scanning/test_role_detail_list.py
+++ b/test/scanning/test_role_detail_list.py
@@ -1,8 +1,9 @@
+import json
 import os
 import unittest
-import json
-from cloudsplaining.scan.role_details import RoleDetail
+
 from cloudsplaining.scan.managed_policy_detail import ManagedPolicyDetails
+from cloudsplaining.scan.role_details import RoleDetail
 
 example_authz_details_file = os.path.abspath(
     os.path.join(
@@ -22,7 +23,7 @@ class TestRoleDetail(unittest.TestCase):
         role_detail_json_input = auth_details_json["RoleDetailList"][2]
         policy_details = ManagedPolicyDetails(auth_details_json.get("Policies"))
 
-        role_detail = RoleDetail(role_detail_json_input, policy_details)
+        role_detail = RoleDetail(role_detail_json_input, policy_details, flag_trust_policies=True)
         expected_detail_policy_results_file = os.path.abspath(
             os.path.join(
                 os.path.dirname(__file__),


### PR DESCRIPTION
This pull request adds support for flagging risky trust policies in IAM roles throughout the scanning workflow. The main change is the introduction of a new `flag_trust_policies` option, which enables additional findings related to trust policy risks in scan results. The option is propagated through the CLI, scanning functions, and relevant classes, and the output is updated to include trust policy findings when the flag is enabled.

**Feature: Flagging Risky Trust Policies**

* Added a new CLI option `--flag-trust-policies` to the `scan` command, allowing users to enable flagging of risky trust policies in IAM roles.
* Propagated the `flag_trust_policies` parameter through the `scan` function, `scan_account_authorization_details`, and constructors for `AuthorizationDetails` and `RoleDetail`, ensuring the flag is respected throughout the scanning workflow. [[1]](diffhunk://#diff-542ad738eeb0b53ce0b8cbc6b860e5074fced959c04dd9cb467b3a3f6f13f469R116) [[2]](diffhunk://#diff-542ad738eeb0b53ce0b8cbc6b860e5074fced959c04dd9cb467b3a3f6f13f469R154) [[3]](diffhunk://#diff-542ad738eeb0b53ce0b8cbc6b860e5074fced959c04dd9cb467b3a3f6f13f469R220) [[4]](diffhunk://#diff-542ad738eeb0b53ce0b8cbc6b860e5074fced959c04dd9cb467b3a3f6f13f469R236) [[5]](diffhunk://#diff-542ad738eeb0b53ce0b8cbc6b860e5074fced959c04dd9cb467b3a3f6f13f469R251) [[6]](diffhunk://#diff-84c769a1442a331faf8c90579be3f984a415492a4f1209f9f7db63ed88fe78d5R38) [[7]](diffhunk://#diff-84c769a1442a331faf8c90579be3f984a415492a4f1209f9f7db63ed88fe78d5R57) [[8]](diffhunk://#diff-84c769a1442a331faf8c90579be3f984a415492a4f1209f9f7db63ed88fe78d5R91) [[9]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR46) [[10]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR58) [[11]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR82) [[12]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR148) [[13]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR177)

**Output Enhancement**

* Updated the `RoleDetail.json` output to include findings for `AssumableByComputeServices` and `AssumableByCrossAccountPrincipal` when `flag_trust_policies` is enabled, providing severity, description, and findings for risky trust policies. [[1]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dL345-R355) [[2]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dL358-R368) [[3]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dR381)

**Testing**

* Modified the role detail test to enable the `flag_trust_policies` flag, ensuring trust policy findings are included in test results. [[1]](diffhunk://#diff-06e0bb427542d6ccfcd3cb590a8cf07102c3b100212f44cbb9a507e87cec74b5R1-R6) [[2]](diffhunk://#diff-06e0bb427542d6ccfcd3cb590a8cf07102c3b100212f44cbb9a507e87cec74b5L25-R26)Add a new command line flag --flag-trust-policies that allows users to control whether trust policy findings are included in role detail output, providing more granular control over which security findings are reported.