### PR TITLE
Add AssumableByAnyPrincipal findings to role detail output

### DIFF
--- a/cloudsplaining/scan/role_details.py
+++ b/cloudsplaining/scan/role_details.py
@@ -378,6 +378,19 @@ class RoleDetail:
                             else []
                         ),
                     },
+                    "AssumableByAnyPrincipal": {
+                        "severity": ISSUE_SEVERITY["AssumableByAnyPrincipal"],
+                        "description": RISK_DEFINITION["AssumableByAnyPrincipal"],
+                        "findings": (
+                            self.assume_role_policy_document.role_assumable_by_any_principal
+                            if self.assume_role_policy_document
+                            and (
+                                ISSUE_SEVERITY["AssumableByAnyPrincipal"] in [x.lower() for x in self.severity]
+                                or not self.severity
+                            )
+                            else []
+                        ),
+                    },
                 }
             )
         return this_role_detail

--- a/cloudsplaining/shared/constants.py
+++ b/cloudsplaining/shared/constants.py
@@ -84,6 +84,7 @@ ISSUE_SEVERITY = {
     "InfrastructureModification": "low",
     "AssumableByComputeService": "low",
     "AssumableByCrossAccountPrincipal": "low",
+    "AssumableByAnyPrincipal": "high",
 }
 
 RISK_DEFINITION = {
@@ -94,7 +95,8 @@ RISK_DEFINITION = {
     "CredentialsExposure": "<p>Credentials Exposure actions return credentials as part of the API response , such as ecr:GetAuthorizationToken, iam:UpdateAccessKey, and others. The full list is maintained here: https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a</p>",
     "InfrastructureModification": "",
     "AssumableByComputeService": "<p>IAM Roles can be assumed by AWS Compute Services (such as EC2, ECS, EKS, or Lambda) can present greater risk than user-defined roles, especially if the AWS Compute service is on an instance that is directly or indirectly exposed to the internet. Flagging these roles is particularly useful to penetration testers (or attackers) under certain scenarios.<br>For example, if an attacker obtains privileges to execute <code>ssm:SendCommand</code> and there are privileged EC2 instances with the SSM agent installed, they can effectively have the privileges of those EC2 instances.</p>",
-    "AssumableByCrossAccountPrincipal": "<p>Roles that can be assumed from other AWS accounts can present a greater risk than roles that can only be assumed within the same AWS account. This is especially true if the trusting account is not owned by your organization.</p>",
+    "AssumableByCrossAccountPrincipal": "<p>IAM Roles that can be assumed from other AWS accounts can present a greater risk than roles that can only be assumed within the same AWS account. This is especially true if the trusting account is not owned by your organization.</p>",
+    "AssumableByAnyPrincipal": "<p>IAM Roles that can be assumed by any principal (i.e. Principal: '*') present a very high risk and should be remediated immediately.</p>",
 }
 
 PRIVILEGE_ESCALATION_METHODS = {

--- a/test/files/scanning/test_role_detail_results.json
+++ b/test/files/scanning/test_role_detail_results.json
@@ -62,8 +62,13 @@
     "severity": "low"
   },
   "AssumableByCrossAccountPrincipal": {
-    "description": "<p>Roles that can be assumed from other AWS accounts can present a greater risk than roles that can only be assumed within the same AWS account. This is especially true if the trusting account is not owned by your organization.</p>",
+    "description": "<p>IAM Roles that can be assumed from other AWS accounts can present a greater risk than roles that can only be assumed within the same AWS account. This is especially true if the trusting account is not owned by your organization.</p>",
     "findings": [],
     "severity": "low"
+  },
+  "AssumableByAnyPrincipal": {
+    "description": "<p>IAM Roles that can be assumed by any principal (i.e. Principal: '*') present a very high risk and should be remediated immediately.</p>",
+    "findings": [],
+    "severity": "high"
   }
 }


### PR DESCRIPTION
Surface roles that can be assumed by any principal (*) or any AWS account root to provide critical visibility into the most dangerous trust policy configurations, helping security teams immediately identify roles that present the highest risk of unauthorized access from any AWS account.

This pull request introduces a new check for IAM roles that can be assumed by any principal, significantly enhancing the detection of high-risk trust policies. It adds logic to identify roles with trust policies that allow assumption by any principal (e.g., `Principal: '*'` or `Principal: 'arn:aws:iam::*:root'`), marks these findings with high severity, and ensures the results are surfaced in both code and test outputs.

### New detection for roles assumable by any principal

* Added the `role_assumable_by_any_principal` property to both `AssumeRolePolicyDocument` and `AssumeRoleStatement`, which identifies if a role can be assumed by any principal (wildcard or any AWS account root). [[1]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5R62-R70) [[2]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5R142-R159)

### Reporting and severity

* Updated `role_details.py` to include findings for `AssumableByAnyPrincipal` in the JSON output, using the new detection logic.
* Assigned a "high" severity to `AssumableByAnyPrincipal` in `shared/constants.py`, and provided a clear risk definition for this issue. [[1]](diffhunk://#diff-15b2db1f8d7430389bfa53b5cff55882537ed8c454e2fb24fa5367edea4c184cR87) [[2]](diffhunk://#diff-15b2db1f8d7430389bfa53b5cff55882537ed8c454e2fb24fa5367edea4c184cL97-R99)

### Testing

* Added comprehensive tests to verify the new detection logic for various trust policy scenarios, ensuring correct behavior for wildcard principals, any root principals, and edge cases.
* Updated test output in `test_role_detail_results.json` to include the new `AssumableByAnyPrincipal` finding and its associated severity and description.

