### PR TITLE
Add AssumableByAnyPrincipalWithConditions findings to role detail output

### DIFF
--- a/cloudsplaining/scan/role_details.py
+++ b/cloudsplaining/scan/role_details.py
@@ -391,6 +391,20 @@ class RoleDetail:
                             else []
                         ),
                     },
+                    "AssumableByAnyPrincipalWithConditions": {
+                        "severity": ISSUE_SEVERITY["AssumableByAnyPrincipalWithConditions"],
+                        "description": RISK_DEFINITION["AssumableByAnyPrincipalWithConditions"],
+                        "findings": (
+                            self.assume_role_policy_document.role_assumable_by_any_principal_with_conditions
+                            if self.assume_role_policy_document
+                            and (
+                                ISSUE_SEVERITY["AssumableByAnyPrincipalWithConditions"]
+                                in [x.lower() for x in self.severity]
+                                or not self.severity
+                            )
+                            else []
+                        ),
+                    },
                 }
             )
         return this_role_detail

--- a/cloudsplaining/shared/constants.py
+++ b/cloudsplaining/shared/constants.py
@@ -85,6 +85,7 @@ ISSUE_SEVERITY = {
     "AssumableByComputeService": "low",
     "AssumableByCrossAccountPrincipal": "low",
     "AssumableByAnyPrincipal": "high",
+    "AssumableByAnyPrincipalWithConditions": "medium",
 }
 
 RISK_DEFINITION = {
@@ -97,6 +98,7 @@ RISK_DEFINITION = {
     "AssumableByComputeService": "<p>IAM Roles can be assumed by AWS Compute Services (such as EC2, ECS, EKS, or Lambda) can present greater risk than user-defined roles, especially if the AWS Compute service is on an instance that is directly or indirectly exposed to the internet. Flagging these roles is particularly useful to penetration testers (or attackers) under certain scenarios.<br>For example, if an attacker obtains privileges to execute <code>ssm:SendCommand</code> and there are privileged EC2 instances with the SSM agent installed, they can effectively have the privileges of those EC2 instances.</p>",
     "AssumableByCrossAccountPrincipal": "<p>IAM Roles that can be assumed from other AWS accounts can present a greater risk than roles that can only be assumed within the same AWS account. This is especially true if the trusting account is not owned by your organization.</p>",
     "AssumableByAnyPrincipal": "<p>IAM Roles that can be assumed by any principal (i.e. Principal: '*') present a very high risk and should be remediated immediately.</p>",
+    "AssumableByAnyPrincipalWithConditions": "<p>IAM Roles that can be assumed by any principal (i.e. Principal: '*') but have conditions present can lead to unexpected outcomes. The conditions should be carefully reviewed to ensure they are not overly permissive.</p>",
 }
 
 PRIVILEGE_ESCALATION_METHODS = {

--- a/test/files/scanning/test_role_detail_results.json
+++ b/test/files/scanning/test_role_detail_results.json
@@ -70,5 +70,10 @@
     "description": "<p>IAM Roles that can be assumed by any principal (i.e. Principal: '*') present a very high risk and should be remediated immediately.</p>",
     "findings": [],
     "severity": "high"
+  },
+  "AssumableByAnyPrincipalWithConditions": {
+    "description": "<p>IAM Roles that can be assumed by any principal (i.e. Principal: '*') but have conditions present can lead to unexpected outcomes. The conditions should be carefully reviewed to ensure they are not overly permissive.</p>",
+    "findings": [],
+    "severity": "medium"
   }
 }


### PR DESCRIPTION
Surface roles that can be assumed by any principal (*) or any AWS account root when conditions are present to provide enhanced visibility into potentially dangerous trust policy configurations. While conditions may appear to provide security controls, they can be overly permissive or contain logical flaws, helping security teams identify roles that require careful review to ensure conditions adequately restrict access and prevent unintended privilege escalation.

This pull request adds support for detecting IAM roles that can be assumed by any principal (wildcard or any AWS account root) when conditions are present in the trust policy. It introduces a new risk category, updates severity and descriptions, and extends both scanning logic and tests to cover these cases.

**New risk detection and reporting:**

* Added a new property `role_assumable_by_any_principal_with_conditions` to `AssumeRoleStatement` and `AssumeRolePolicyDocument`, which identifies roles assumable by any principal only when conditions are present in the statement. [[1]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5R71-R79) [[2]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5R164-R189)
* Updated the role details JSON output in `role_details.py` to include findings for `AssumableByAnyPrincipalWithConditions`.

**Risk metadata and documentation:**

* Added a new risk severity level (`medium`) and description for `AssumableByAnyPrincipalWithConditions` in `constants.py`, and updated test data to reflect this new risk. [[1]](diffhunk://#diff-15b2db1f8d7430389bfa53b5cff55882537ed8c454e2fb24fa5367edea4c184cR88) [[2]](diffhunk://#diff-15b2db1f8d7430389bfa53b5cff55882537ed8c454e2fb24fa5367edea4c184cR101) [[3]](diffhunk://#diff-db7efb559c14a77b80cdeefe9d227804effb12b7e30680efe95322f8443c8aa7R73-R77)

**Testing and validation:**

* Added comprehensive unit tests to verify detection of wildcard and any root principals with conditions, including negative cases and aggregation logic in the policy document. [[1]](diffhunk://#diff-bc8aa6b0a21f56d9609e4b477a06d494cdfa322a80033470e4d4296e5a1eaa5bR259-R267) [[2]](diffhunk://#diff-bc8aa6b0a21f56d9609e4b477a06d494cdfa322a80033470e4d4296e5a1eaa5bR283-R384)

