### PR TITLE
Add documentation for new trust policy findings

### DIFF
--- a/docs/glossary/roles-assumable-by-any-principal-with-conditions.md
+++ b/docs/glossary/roles-assumable-by-any-principal-with-conditions.md
@@ -1,0 +1,45 @@
+IAM Roles that can be assumed by any principal (i.e. Principal: '*') but have conditions present can lead to unexpected outcomes. The conditions should be carefully reviewed to ensure they are not overly permissive.
+
+While the presence of conditions may appear to provide security controls, these configurations still present significant risk and require careful evaluation. The conditions may:
+
+- **Be overly permissive** - Allow broader access than intended
+- **Contain logical flaws** - Have gaps that can be exploited
+- **Be circumventable** - Use conditions that can be easily satisfied by attackers
+- **Provide false security** - Give the impression of protection while being ineffective
+
+### Common Risky Condition Examples
+
+1. **IP-based restrictions that are too broad** - Allowing entire IP ranges instead of specific addresses
+2. **Time-based conditions** - Allowing access during broad time windows
+3. **User agent conditions** - Easily spoofable browser or client identifiers
+4. **Weak external ID requirements** - Using predictable or well-known external IDs
+5. **MFA conditions without proper validation** - Not properly verifying MFA device ownership
+
+### Why This Still Represents Risk
+
+Even with conditions, these roles are fundamentally different from properly scoped trust policies because:
+
+- **Attack surface remains large** - Any AWS user can attempt to assume the role
+- **Condition bypass potential** - Attackers may find ways to satisfy the conditions
+- **Complexity increases risk** - More complex policies are harder to audit and maintain
+- **Future changes may weaken security** - Policy updates might inadvertently relax conditions
+
+### Recommended Actions
+
+1. **Audit conditions thoroughly** - Review each condition for potential weaknesses or bypass methods
+2. **Consider principal-specific alternatives** - Replace wildcard principals with specific account IDs or ARNs where possible
+3. **Implement defense in depth** - Use multiple complementary conditions rather than relying on a single control
+4. **Regular review and testing** - Periodically test that conditions work as expected and cannot be bypassed
+5. **Monitor assumption attempts** - Set up CloudTrail monitoring for role assumption attempts that fail condition checks
+6. **Document intended use cases** - Clearly document why wildcard principals are necessary and what the conditions are meant to protect against
+
+### Best Practices for Conditions
+
+If wildcard principals are truly necessary, ensure conditions are:
+- **Specific and restrictive** - Use narrow ranges and exact matches where possible
+- **Multi-layered** - Combine multiple condition types for stronger protection
+- **Regularly updated** - Keep IP ranges, time windows, and other dynamic values current
+- **Properly tested** - Verify that legitimate use cases work and unauthorized access is blocked
+- **Well-documented** - Maintain clear documentation of the security model and assumptions
+
+Roles with this finding should be prioritized for review to ensure the conditions provide adequate protection and align with your organization's security requirements.

--- a/docs/glossary/roles-assumable-by-any-principal.md
+++ b/docs/glossary/roles-assumable-by-any-principal.md
@@ -1,0 +1,26 @@
+IAM Roles that can be assumed by any principal (i.e. Principal: '*') present a very high risk and should be remediated immediately.
+
+These configurations are extremely dangerous because they effectively make the role publicly assumable by anyone with valid AWS credentials, regardless of which AWS account they belong to. This creates a critical security vulnerability that can lead to:
+
+- **Unauthorized access**: Any AWS user from any account can assume the role
+- **Privilege escalation**: Attackers with minimal AWS access can gain elevated permissions
+- **Data breaches**: If the role has access to sensitive resources, those become exposed
+- **Compliance violations**: Many security frameworks prohibit such open access patterns
+
+### Common Scenarios Where This Occurs
+
+1. **Misconfigured cross-account access** - Attempting to allow access from multiple accounts but using wildcard instead of specific account IDs
+2. **Development/testing shortcuts** - Using overly permissive policies during development that make it to production
+3. **Copy-paste errors** - Reusing policy templates without proper customization
+
+### Immediate Remediation Required
+
+Roles with this finding should be considered a **critical security incident** and require immediate attention:
+
+1. **Identify the intended use case** - Determine what legitimate access the role was meant to provide
+2. **Replace wildcards with specific principals** - Use exact account IDs, user ARNs, or service principals
+3. **Add conditions** - Implement additional constraints like IP restrictions, MFA requirements, or time-based access
+4. **Review role permissions** - Ensure the role follows principle of least privilege
+5. **Audit access logs** - Check CloudTrail for any unauthorized role assumptions
+
+Unlike roles with conditions that might provide some protection, roles flagged with this finding have **no safeguards** and should be treated as publicly accessible resources.

--- a/docs/glossary/roles-assumable-by-compute-service.md
+++ b/docs/glossary/roles-assumable-by-compute-service.md
@@ -1,6 +1,3 @@
-## Roles Assumable by Compute Services
-
 IAM Roles can be assumed by AWS Compute Services (such as EC2, ECS, EKS, or Lambda) can present greater risk than user-defined roles, especially if the AWS Compute service is on an instance that is directly or indirectly exposed to the internet. Flagging these roles is particularly useful to penetration testers (or attackers) under certain scenarios. 
 
 For example, if an attacker obtains privileges to execute `ssm:SendCommand` and there are privileged EC2 instances with the SSM agent installed, they can effectively have the privileges of those EC2 instances. Remote Code Execution via AWS Systems Manager Agent was already a known escalation/exploitation path, but Cloudsplaining can make the process of identifying theses cases easier.
-

--- a/docs/glossary/roles-assumable-by-cross-account-principal.md
+++ b/docs/glossary/roles-assumable-by-cross-account-principal.md
@@ -1,0 +1,15 @@
+IAM Roles that can be assumed from other AWS accounts can present a greater risk than roles that can only be assumed within the same AWS account. This is especially true if the trusting account is not owned by your organization.
+
+Cross-account role assumption is a common pattern for legitimate use cases such as:
+- Service providers accessing customer resources
+- Third-party integrations
+- Multi-account AWS Organizations setups
+- Partner integrations
+
+However, these configurations require careful review to ensure that:
+- The external account is trusted and belongs to your organization or a legitimate partner
+- The role's permissions are appropriately scoped for the cross-account use case
+- Monitoring and logging are in place to track cross-account access
+- The trust relationship includes appropriate conditions to limit access scope
+
+Roles flagged with this finding should be reviewed to verify that cross-account access is intentional and properly secured. Pay particular attention to roles that grant broad permissions or access to sensitive resources, as compromise of the external account could lead to unauthorized access to your AWS resources.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,11 +6,11 @@ repo_url: https://github.com/salesforce/cloudsplaining
 theme: material
 use_directory_urls: true
 markdown_extensions:
-    - codehilite
-    - tables
-    - admonition
-    - pymdownx.details
-    - pymdownx.superfences
+  - codehilite
+  - tables
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
 plugins:
   - search
   - mkdocstrings:
@@ -22,45 +22,48 @@ plugins:
       watch:
         - cloudsplaining/
 nav:
-  - "<b>Home</b>": 'index.md'
+  - "<b>Home</b>": "index.md"
   - "<b>User Guide</b>":
-    - Introduction: 'user-guide/overview.md'
-    - Installation: 'user-guide/installation.md'
-    - Downloading Account IAM Details: 'user-guide/download.md'
-    - Creating an Exclusions File: 'user-guide/create-exclusions-file.md'
-    - Scanning a single AWS account: 'user-guide/scan-account.md'
-    - Scanning a single policy: 'user-guide/scan-policy-file.md'
-    - Scanning multiple AWS accounts: 'user-guide/scan-multiple-accounts.md'
-    - Troubleshooting: 'user-guide/troubleshooting.md'
+      - Introduction: "user-guide/overview.md"
+      - Installation: "user-guide/installation.md"
+      - Downloading Account IAM Details: "user-guide/download.md"
+      - Creating an Exclusions File: "user-guide/create-exclusions-file.md"
+      - Scanning a single AWS account: "user-guide/scan-account.md"
+      - Scanning a single policy: "user-guide/scan-policy-file.md"
+      - Scanning multiple AWS accounts: "user-guide/scan-multiple-accounts.md"
+      - Troubleshooting: "user-guide/troubleshooting.md"
 
   - "<b>Report Contents</b>":
-    - Overview: 'report/overview.md'
-    - Triage: 'report/triage.md'
-    - Remediation: 'report/remediation.md'
-    - Validation: 'report/validation.md'
+      - Overview: "report/overview.md"
+      - Triage: "report/triage.md"
+      - Remediation: "report/remediation.md"
+      - Validation: "report/validation.md"
 
   - "<b>Glossary</b>":
-    - Privilege Escalation: 'glossary/privilege-escalation.md'
-    - Resource Exposure: 'glossary/resource-exposure.md'
-    - Data Exfiltration: 'glossary/data-exfiltration.md'
-    - Credentials Exposure: 'glossary/credentials-exposure.md'
-    - Infrastructure Modification: 'glossary/infrastructure-modification.md'
-    - Service Wildcard: 'glossary/service-wildcard.md'
-    - Roles Assumable by Compute Service: 'glossary/roles-assumable-by-compute-service.md'
-    - Trust Policy: 'glossary/trust-policy.md'
+      - Privilege Escalation: "glossary/privilege-escalation.md"
+      - Resource Exposure: "glossary/resource-exposure.md"
+      - Data Exfiltration: "glossary/data-exfiltration.md"
+      - Credentials Exposure: "glossary/credentials-exposure.md"
+      - Infrastructure Modification: "glossary/infrastructure-modification.md"
+      - Service Wildcard: "glossary/service-wildcard.md"
+      - Roles Assumable by Any Principal: "glossary/roles-assumable-by-any-principal.md"
+      - Roles Assumable by Any Principal with Condition: "glossary/roles-assumable-by-any-principal-with-conditions.md"
+      - Roles Assumable by Compute Service: "glossary/roles-assumable-by-compute-service.md"
+      - Roles Assumable by Cross Account Principal: "glossary/roles-assumable-by-cross-account-principal.md"
+      - Trust Policy: "glossary/trust-policy.md"
 
   - "<b>Contributing</b>":
-    - Contributing: 'contributing/contributing.md'
-    - Documentation: 'contributing/documentation.md'
-    - JavaScript: 'contributing/javascript.md'
-    - Python: 'contributing/python.md'
-    - JSON Schema: 'contributing/results-json-schema.md'
-    - Release Drafter: 'contributing/release-drafter.md'
-    - Report Generation: 'contributing/report.md'
-    - Testing: 'contributing/testing.md'
-    - Versioning: 'contributing/versioning.md'
+      - Contributing: "contributing/contributing.md"
+      - Documentation: "contributing/documentation.md"
+      - JavaScript: "contributing/javascript.md"
+      - Python: "contributing/python.md"
+      - JSON Schema: "contributing/results-json-schema.md"
+      - Release Drafter: "contributing/release-drafter.md"
+      - Report Generation: "contributing/report.md"
+      - Testing: "contributing/testing.md"
+      - Versioning: "contributing/versioning.md"
 
   - "<b>Appendices</b>":
-    - FAQ: 'appendices/faq.md'
-    - Comparison to other tools: 'appendices/comparison-to-other-tools.md'
-    - Jira Ticket Automation: 'appendices/jira-ticket-automation.md'
+      - FAQ: "appendices/faq.md"
+      - Comparison to other tools: "appendices/comparison-to-other-tools.md"
+      - Jira Ticket Automation: "appendices/jira-ticket-automation.md"


### PR DESCRIPTION
Provide documentation for the three new trust policy findings (AssumableByCrossAccountPrincipal, AssumableByAnyPrincipal, and AssumableByAnyPrincipalWithConditions) to help security teams understand the risks associated with each type of role assumption configuration and provide actionable guidance for remediation and review.

This pull request updates the documentation and navigation structure to provide clearer guidance on IAM role risks and improve the organization of glossary topics. The main changes include adding new glossary entries for IAM role risk scenarios, enhancing existing documentation, and updating the navigation in `mkdocs.yml` to reflect these additions.

**Documentation improvements for IAM role risks:**

* Added `roles-assumable-by-any-principal.md` to explain the critical risks of IAM roles with a wildcard principal and no conditions, including remediation steps and common scenarios.
* Added `roles-assumable-by-any-principal-with-conditions.md` to describe risks associated with wildcard principals even when conditions are present, including examples of risky conditions and recommended actions.
* Added `roles-assumable-by-cross-account-principal.md` to clarify risks and best practices for roles assumable by principals from other AWS accounts.

**Navigation and glossary updates:**

* Updated `mkdocs.yml` to add the new glossary entries and reorganize navigation for improved clarity and consistency, including switching to double quotes for file paths.

**Minor documentation cleanup:**

* Removed redundant header from `roles-assumable-by-compute-service.md` for consistency.
