### PR TITLE
Add known-accounts exclusions to reduce cross-account principal false…

### DIFF
--- a/cloudsplaining/scan/role_details.py
+++ b/cloudsplaining/scan/role_details.py
@@ -193,7 +193,9 @@ class RoleDetail:
                     # If we can't parse the account ID, continue without it
                     current_account_id = get_account_from_arn(self.arn)
 
-            self.assume_role_policy_document = AssumeRolePolicyDocument(assume_role_policy, current_account_id)
+            self.assume_role_policy_document = AssumeRolePolicyDocument(
+                assume_role_policy, current_account_id, exclusions
+            )
 
         # TODO: Create a class for InstanceProfileList
         self.instance_profile_list = role_detail.get("InstanceProfileList", [])

--- a/cloudsplaining/shared/constants.py
+++ b/cloudsplaining/shared/constants.py
@@ -54,6 +54,12 @@ include-actions:
 # Write actions to include from the results, such as kms:Decrypt
 exclude-actions:
   - ""
+# Known AWS Account IDs to exclude from assume role analysis.
+# Add your organization's account IDs and any thrid party vendor's
+# account IDs here to avoid false positives.
+# https://github.com/fwdcloudsec/known_aws_accounts/blob/main/accounts.yaml
+known-accounts:
+  - ""
 """
 
 MULTI_ACCOUNT_CONFIG_TEMPLATE = """accounts:

--- a/cloudsplaining/shared/default-exclusions.yml
+++ b/cloudsplaining/shared/default-exclusions.yml
@@ -31,4 +31,9 @@ include-actions:
 # Write actions to include from the results, such as kms:Decrypt
 exclude-actions:
   - ""
-
+# Known AWS Account IDs to exclude from assume role analysis.
+# Add your organization's account IDs and any thrid party vendor's
+# account IDs here to avoid false positives.
+# https://github.com/fwdcloudsec/known_aws_accounts/blob/main/accounts.yaml
+known-accounts:
+  - ""

--- a/cloudsplaining/shared/exclusions.py
+++ b/cloudsplaining/shared/exclusions.py
@@ -28,6 +28,7 @@ class Exclusions:
         self.users = self._users()
         self.groups = self._groups()
         self.policies = self._policies()
+        self.known_accounts = self._known_accounts()
 
     def _roles(self) -> list[str]:
         provided_roles = self.config.get("roles", [])
@@ -64,6 +65,12 @@ class Exclusions:
         # Set to lowercase so subsequent evaluations are faster.
         always_exclude_actions = [x.lower() for x in exclude_actions]
         return always_exclude_actions
+
+    def _known_accounts(self) -> list[str]:
+        provided_known_accounts = self.config.get("known-accounts", [])
+        # Normalize for comparisons - remove empty strings
+        known_accounts = [account for account in provided_known_accounts if account.strip()]
+        return known_accounts
 
     def is_action_always_included(self, action_in_question: str) -> bool | str:
         """

--- a/cloudsplaining/shared/validation.py
+++ b/cloudsplaining/shared/validation.py
@@ -22,6 +22,7 @@ EXCLUSIONS_TEMPLATE_SCHEMA = Schema(
         Optional("groups"): [str],
         Optional("exclude-actions"): [str],
         Optional("include-actions"): [str],
+        Optional("known-accounts"): [str],
     }
 )
 

--- a/test/files/test-exclusions.yml
+++ b/test/files/test-exclusions.yml
@@ -29,4 +29,9 @@ include-actions:
 # Write actions to include from the results, such as kms:Decrypt
 exclude-actions:
   - ""
-
+# Known AWS Account IDs to exclude from assume role analysis.
+# Add your organization's account IDs and any thrid party vendor's
+# account IDs here to avoid false positives.
+# https://github.com/fwdcloudsec/known_aws_accounts/blob/main/accounts.yaml
+known-accounts:
+  - ""


### PR DESCRIPTION
… positives

Allow users to specify known AWS account IDs in the exclusions configuration to filter out trusted accounts from cross-account assumability findings, reducing noise from legitimate organizational accounts and third-party vendor accounts while maintaining security visibility for unknown external principals.

This pull request introduces support for excluding specific AWS account IDs from cross-account role assumption analysis. The main changes add a `known-accounts` exclusion mechanism, allowing users to specify accounts that should not trigger cross-account findings, reducing false positives in trust policy scans. The exclusions are now passed through relevant classes, and the logic for cross-account principal detection has been updated to respect these exclusions. Tests and configuration files have also been updated to cover the new functionality.

### Exclusion mechanism for known AWS accounts

* Added a `known-accounts` field to exclusion configuration files (`cloudsplaining/shared/constants.py`, `cloudsplaining/shared/default-exclusions.yml`, `test/files/test-exclusions.yml`) and updated validation logic to support it. [[1]](diffhunk://#diff-15b2db1f8d7430389bfa53b5cff55882537ed8c454e2fb24fa5367edea4c184cR57-R62) [[2]](diffhunk://#diff-781a0a1bc9ec20ec5fd384706d84f7adf1609078d021b8bdd54fe44c36e5633fL34-R39) [[3]](diffhunk://#diff-95395a047cbf2c7522ecb4ca3b9e85b296f5f10da7a5331ef311a693ce2e218eR25) [[4]](diffhunk://#diff-f9b8e6221e6d2f54add30414426642a78c332b8f4685291730a42b620bd89e45L32-R37)
* Updated the `Exclusions` class to parse and normalize the new `known-accounts` field, making it accessible for policy analysis. [[1]](diffhunk://#diff-8dc178a47a5f0bb95e915aa4aaf4e61647aff030653c31a2f584a7c671a61770R31) [[2]](diffhunk://#diff-8dc178a47a5f0bb95e915aa4aaf4e61647aff030653c31a2f584a7c671a61770R69-R74)

### Trust policy scanning logic

* Modified `AssumeRolePolicyDocument` and `AssumeRoleStatement` to accept and utilize the `exclusions` parameter, filtering out principals from excluded accounts during cross-account analysis. [[1]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5R21-R24) [[2]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5L31-R52) [[3]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5L86-R104) [[4]](diffhunk://#diff-7a56b3a8771af08cf0dace21cc66fb76a70c10184eada79647a8bc886dd681b5L148-R167) [[5]](diffhunk://#diff-5f0300296e0930b2b5ace51fa56b5560915cfd259842147d8d3318197b33f78dL196-R198)

### Test coverage

* Expanded unit tests for trust policy scanning to verify correct exclusion of known accounts, including scenarios for full, partial, and combined filtering. [[1]](diffhunk://#diff-bc8aa6b0a21f56d9609e4b477a06d494cdfa322a80033470e4d4296e5a1eaa5bL3-R4) [[2]](diffhunk://#diff-bc8aa6b0a21f56d9609e4b477a06d494cdfa322a80033470e4d4296e5a1eaa5bL147) [[3]](diffhunk://#diff-bc8aa6b0a21f56d9609e4b477a06d494cdfa322a80033470e4d4296e5a1eaa5bR176-R203) [[4]](diffhunk://#diff-bc8aa6b0a21f56d9609e4b477a06d494cdfa322a80033470e4d4296e5a1eaa5bR241-L215)

